### PR TITLE
Chore/migrate campaign enpoints

### DIFF
--- a/API/src/common/helper/escape-regex.helper.ts
+++ b/API/src/common/helper/escape-regex.helper.ts
@@ -1,0 +1,3 @@
+export function escapeRegex(regexStr: string): string {
+  return regexStr.replace(/[/\-\\^$*+?.()|[\]{}]/g, '\\$&');
+}

--- a/API/src/main.ts
+++ b/API/src/main.ts
@@ -4,7 +4,7 @@ import {
   FastifyAdapter,
   NestFastifyApplication,
 } from '@nestjs/platform-fastify';
-import { ValidationPipe } from '@nestjs/common';
+import { ValidationPipe, VersioningType } from '@nestjs/common';
 import { DocumentBuilder, SwaggerModule } from '@nestjs/swagger';
 import { Logger } from 'pino-nestjs';
 
@@ -15,7 +15,14 @@ async function bootstrap() {
     { bufferLogs: true },
   );
 
-  app.useGlobalPipes(new ValidationPipe());
+  app.useGlobalPipes(new ValidationPipe({ whitelist: true, transform: true }));
+
+  app.enableVersioning({
+    type: VersioningType.URI,
+    defaultVersion: '1',
+  });
+
+  app.setGlobalPrefix('api');
 
   const config = new DocumentBuilder()
     .setTitle('RevYou')
@@ -24,7 +31,7 @@ async function bootstrap() {
     .build();
 
   const documentFactory = () => SwaggerModule.createDocument(app, config);
-  SwaggerModule.setup('api/v1/docs', app, documentFactory);
+  SwaggerModule.setup('api/:version/docs', app, documentFactory);
 
   if (process.env.NODE_ENV === 'production') {
     app.useLogger(app.get(Logger));

--- a/API/src/modules/campaign/campaign.controller.spec.ts
+++ b/API/src/modules/campaign/campaign.controller.spec.ts
@@ -1,0 +1,18 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { CampaignController } from './campaign.controller';
+
+describe('CampaignController', () => {
+  let controller: CampaignController;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [CampaignController],
+    }).compile();
+
+    controller = module.get<CampaignController>(CampaignController);
+  });
+
+  it('should be defined', () => {
+    expect(controller).toBeDefined();
+  });
+});

--- a/API/src/modules/campaign/campaign.controller.ts
+++ b/API/src/modules/campaign/campaign.controller.ts
@@ -1,15 +1,8 @@
-import {
-  Body,
-  Controller,
-  Get,
-  Param,
-  Patch,
-  Post,
-  Version,
-} from '@nestjs/common';
+import { Body, Controller, Get, Param, Patch, Post } from '@nestjs/common';
 import { CampaignService } from './campaign.service';
 import { CampaignDto } from './dto/campaign.dto';
 import { ApiOperation, ApiParam, ApiResponse, ApiTags } from '@nestjs/swagger';
+import { FeedbackDto } from './dto/feedback.dto';
 
 @Controller('campaigns')
 @ApiTags('Campaigns')
@@ -82,130 +75,13 @@ export class CampaignController {
   @ApiResponse({ status: 400, description: 'Bad Request' })
   @ApiResponse({ status: 404, description: 'Not found' })
   @ApiResponse({ status: 500, description: 'Internal server error' })
-  async saveCampaignFeedback(@Body() feedback: any) {
-    return 'TBD';
-    // const { campaignId, linkUuid, responseContents } = feedback;
-    // return await this.campaignService.saveCampaignFeedback(
-    //   campaignId,
-    //   linkUuid,
-    //   responseContents,
-    // );
-  }
-
-  @Patch('/save-feedback')
-  @Version('2')
-  @ApiOperation({ summary: 'Save campaign feedback' })
-  @ApiResponse({ status: 200, description: 'OK' })
-  @ApiResponse({ status: 400, description: 'Bad Request' })
-  @ApiResponse({ status: 404, description: 'Not found' })
-  @ApiResponse({ status: 500, description: 'Internal server error' })
-  async saveCampaignFeedbackV2(@Body() feedback: any) {
-    return 'TBD v2';
-    // const { campaignId, linkUuid, responseContents } = feedback;
-    // return await this.campaignService.saveCampaignFeedback(
-    //   campaignId,
-    //   linkUuid,
-    //   responseContents,
-    // );
+  async saveCampaignFeedback(@Body() feedback: FeedbackDto) {
+    console.log('Received feedback data(controller):', feedback);
+    const { campaignId, linkUuid, responseContents } = feedback;
+    return await this.campaignService.saveCampaignFeedback(
+      campaignId,
+      linkUuid,
+      responseContents,
+    );
   }
 }
-
-// const createNewCampaign = async (req, res) => {
-//   const { title, description, createdBy, projects } = req.body;
-//   let campaign;
-//   try {
-//     if (!title || !createdBy || !projects) {
-//       return res
-//         .status(400)
-//         .json({ message: 'Title, createdBy, and projects are required' });
-//     }
-//     campaign = await createCampaign(title, description, createdBy, projects);
-//   } catch (error) {
-//     console.error('Error creating campaign:', error);
-//     return res.status(500).json({ message: 'Internal server error' });
-//   }
-//   res.status(201).json({
-//     message: 'Campaign created successfully',
-//     campaign: campaign,
-//   });
-// };
-
-// const getCampaignsByUserId = async (req, res) => {
-//   const userId = req.params.userId;
-//   if (!userId) {
-//     return res.status(400).json({ message: 'User ID is required' });
-//   }
-//   try {
-//     const campaigns = await getCampaignsByUser(userId);
-//     res.status(200).json(campaigns);
-//   } catch (error) {
-//     console.error('Error fetching campaigns:', error);
-//     res.status(500).json({ message: 'Internal server error' });
-//   }
-// };
-
-// const getCampaignByIdController = async (req, res) => {
-//   const campaignId = req.params.campaignId;
-//   console.log('Fetching campaign with ID:', campaignId);
-//   if (!campaignId) {
-//     return res.status(400).json({ message: 'Campaign ID is not set' });
-//   }
-//   try {
-//     const campaign = await getCampaignByIdService(campaignId);
-//     if (!campaign) {
-//       return res.status(404).json({ message: 'Campaign not found' });
-//     }
-//     res.status(200).json(campaign);
-//   } catch (error) {
-//     console.error('Error fetching campaign:', error);
-//     res.status(500).json({ message: 'Internal server error' });
-//   }
-// };
-
-// const getCampaignByLinkController = async (req, res) => {
-//   const linkUuid = req.params.linkUuid;
-//   console.log('Fetching campaign with link:', linkUuid);
-//   if (!linkUuid) {
-//     return res.status(400).json({ message: 'Link is not set' });
-//   }
-//   try {
-//     const campaign = await getCampaignByLinkService(linkUuid);
-//     if (!campaign) {
-//       return res.status(404).json({ message: 'Campaign not found' });
-//     }
-//     res.status(200).json(campaign);
-//   } catch (error) {
-//     console.error('Error fetching campaign by link:', error);
-//     res.status(500).json({ message: 'Internal server error' });
-//   }
-// };
-
-// const saveCampaignFeedbackController = async (req, res) => {
-//   const { campaignId, linkUuid, responseContents } = req.body;
-//   if (!campaignId || !linkUuid || !responseContents) {
-//     return res
-//       .status(400)
-//       .json({ message: 'Campaign ID, link UUID, and feedback are required' });
-//   }
-//   try {
-//     const updatedCampaign = await saveCampaignFeedbackService(
-//       campaignId,
-//       linkUuid,
-//       responseContents,
-//     );
-//     if (!updatedCampaign) {
-//       return res
-//         .status(404)
-//         .json({ message: 'Campaign not found or feedback not saved' });
-//     }
-//     res
-//       .status(200)
-//       .json({
-//         message: 'Feedback saved successfully',
-//         campaign: updatedCampaign,
-//       });
-//   } catch (error) {
-//     console.error('Error saving campaign feedback:', error);
-//     res.status(500).json({ message: 'Internal server error' });
-//   }
-// };

--- a/API/src/modules/campaign/campaign.controller.ts
+++ b/API/src/modules/campaign/campaign.controller.ts
@@ -15,7 +15,6 @@ export class CampaignController {
   @ApiResponse({ status: 400, description: 'Bad Request' })
   @ApiResponse({ status: 500, description: 'Internal server error' })
   async createNewCampaign(@Body() campaign: CampaignDto) {
-    console.log('Received campaign data:', campaign);
     return await this.campaignService.createCampaign(
       campaign.title,
       campaign.createdBy,
@@ -76,7 +75,6 @@ export class CampaignController {
   @ApiResponse({ status: 404, description: 'Not found' })
   @ApiResponse({ status: 500, description: 'Internal server error' })
   async saveCampaignFeedback(@Body() feedback: FeedbackDto) {
-    console.log('Received feedback data(controller):', feedback);
     const { campaignId, linkUuid, responseContents } = feedback;
     return await this.campaignService.saveCampaignFeedback(
       campaignId,

--- a/API/src/modules/campaign/campaign.controller.ts
+++ b/API/src/modules/campaign/campaign.controller.ts
@@ -1,0 +1,211 @@
+import {
+  Body,
+  Controller,
+  Get,
+  Param,
+  Patch,
+  Post,
+  Version,
+} from '@nestjs/common';
+import { CampaignService } from './campaign.service';
+import { CampaignDto } from './dto/campaign.dto';
+import { ApiOperation, ApiParam, ApiResponse, ApiTags } from '@nestjs/swagger';
+
+@Controller('campaigns')
+@ApiTags('Campaigns')
+export class CampaignController {
+  constructor(private readonly campaignService: CampaignService) {}
+
+  @Post('/')
+  @ApiOperation({ summary: 'Create a new campaign' })
+  @ApiResponse({ status: 201, description: 'Campaign created successfully.' })
+  @ApiResponse({ status: 400, description: 'Bad Request' })
+  @ApiResponse({ status: 500, description: 'Internal server error' })
+  async createNewCampaign(@Body() campaign: CampaignDto) {
+    console.log('Received campaign data:', campaign);
+    return await this.campaignService.createCampaign(
+      campaign.title,
+      campaign.createdBy,
+      campaign.projects,
+      campaign.description,
+    );
+  }
+
+  @Get('/user/:userId')
+  @ApiOperation({
+    summary: 'Get campaigns by user ID',
+    description: 'Retrieve all campaigns created by a specific user.',
+  })
+  @ApiResponse({
+    status: 200,
+    description: 'OK',
+  })
+  @ApiResponse({ status: 400, description: 'Bad Request' })
+  @ApiResponse({ status: 404, description: 'Not found' })
+  @ApiResponse({ status: 500, description: 'Internal server error' })
+  async getCampaignsByUserId(@Param('userId') userId: string) {
+    return await this.campaignService.getCampaignsByUser(userId);
+  }
+
+  @Get('/campaign/:campaignId')
+  @ApiOperation({
+    summary: 'Get campaign by ID',
+    description: 'Retrieve a campaign by its ID.',
+  })
+  @ApiParam({ name: 'campaignId', description: 'The ID of the campaign' })
+  @ApiResponse({ status: 200, description: 'OK' })
+  @ApiResponse({ status: 404, description: 'Not found' })
+  @ApiResponse({ status: 500, description: 'Internal server error' })
+  async getCampaignById(@Param('campaignId') campaignId: string) {
+    return await this.campaignService.getCampaignById(campaignId);
+  }
+
+  @Get('/link/:linkUuid')
+  @ApiOperation({
+    summary: 'Get campaign by link',
+    description: 'Retrieve a campaign using a unique link identifier.',
+  })
+  @ApiParam({ name: 'linkUuid', description: 'The unique link identifier' })
+  @ApiResponse({
+    status: 200,
+    description: 'OK',
+  })
+  @ApiResponse({ status: 404, description: 'Not found' })
+  @ApiResponse({ status: 500, description: 'Internal server error' })
+  async getCampaignByLink(@Param('linkUuid') linkUuid: string) {
+    return await this.campaignService.getCampaignByLink(linkUuid);
+  }
+
+  @Patch('/save-feedback')
+  @ApiOperation({ summary: 'Save campaign feedback' })
+  @ApiResponse({ status: 200, description: 'OK' })
+  @ApiResponse({ status: 400, description: 'Bad Request' })
+  @ApiResponse({ status: 404, description: 'Not found' })
+  @ApiResponse({ status: 500, description: 'Internal server error' })
+  async saveCampaignFeedback(@Body() feedback: any) {
+    return 'TBD';
+    // const { campaignId, linkUuid, responseContents } = feedback;
+    // return await this.campaignService.saveCampaignFeedback(
+    //   campaignId,
+    //   linkUuid,
+    //   responseContents,
+    // );
+  }
+
+  @Patch('/save-feedback')
+  @Version('2')
+  @ApiOperation({ summary: 'Save campaign feedback' })
+  @ApiResponse({ status: 200, description: 'OK' })
+  @ApiResponse({ status: 400, description: 'Bad Request' })
+  @ApiResponse({ status: 404, description: 'Not found' })
+  @ApiResponse({ status: 500, description: 'Internal server error' })
+  async saveCampaignFeedbackV2(@Body() feedback: any) {
+    return 'TBD v2';
+    // const { campaignId, linkUuid, responseContents } = feedback;
+    // return await this.campaignService.saveCampaignFeedback(
+    //   campaignId,
+    //   linkUuid,
+    //   responseContents,
+    // );
+  }
+}
+
+// const createNewCampaign = async (req, res) => {
+//   const { title, description, createdBy, projects } = req.body;
+//   let campaign;
+//   try {
+//     if (!title || !createdBy || !projects) {
+//       return res
+//         .status(400)
+//         .json({ message: 'Title, createdBy, and projects are required' });
+//     }
+//     campaign = await createCampaign(title, description, createdBy, projects);
+//   } catch (error) {
+//     console.error('Error creating campaign:', error);
+//     return res.status(500).json({ message: 'Internal server error' });
+//   }
+//   res.status(201).json({
+//     message: 'Campaign created successfully',
+//     campaign: campaign,
+//   });
+// };
+
+// const getCampaignsByUserId = async (req, res) => {
+//   const userId = req.params.userId;
+//   if (!userId) {
+//     return res.status(400).json({ message: 'User ID is required' });
+//   }
+//   try {
+//     const campaigns = await getCampaignsByUser(userId);
+//     res.status(200).json(campaigns);
+//   } catch (error) {
+//     console.error('Error fetching campaigns:', error);
+//     res.status(500).json({ message: 'Internal server error' });
+//   }
+// };
+
+// const getCampaignByIdController = async (req, res) => {
+//   const campaignId = req.params.campaignId;
+//   console.log('Fetching campaign with ID:', campaignId);
+//   if (!campaignId) {
+//     return res.status(400).json({ message: 'Campaign ID is not set' });
+//   }
+//   try {
+//     const campaign = await getCampaignByIdService(campaignId);
+//     if (!campaign) {
+//       return res.status(404).json({ message: 'Campaign not found' });
+//     }
+//     res.status(200).json(campaign);
+//   } catch (error) {
+//     console.error('Error fetching campaign:', error);
+//     res.status(500).json({ message: 'Internal server error' });
+//   }
+// };
+
+// const getCampaignByLinkController = async (req, res) => {
+//   const linkUuid = req.params.linkUuid;
+//   console.log('Fetching campaign with link:', linkUuid);
+//   if (!linkUuid) {
+//     return res.status(400).json({ message: 'Link is not set' });
+//   }
+//   try {
+//     const campaign = await getCampaignByLinkService(linkUuid);
+//     if (!campaign) {
+//       return res.status(404).json({ message: 'Campaign not found' });
+//     }
+//     res.status(200).json(campaign);
+//   } catch (error) {
+//     console.error('Error fetching campaign by link:', error);
+//     res.status(500).json({ message: 'Internal server error' });
+//   }
+// };
+
+// const saveCampaignFeedbackController = async (req, res) => {
+//   const { campaignId, linkUuid, responseContents } = req.body;
+//   if (!campaignId || !linkUuid || !responseContents) {
+//     return res
+//       .status(400)
+//       .json({ message: 'Campaign ID, link UUID, and feedback are required' });
+//   }
+//   try {
+//     const updatedCampaign = await saveCampaignFeedbackService(
+//       campaignId,
+//       linkUuid,
+//       responseContents,
+//     );
+//     if (!updatedCampaign) {
+//       return res
+//         .status(404)
+//         .json({ message: 'Campaign not found or feedback not saved' });
+//     }
+//     res
+//       .status(200)
+//       .json({
+//         message: 'Feedback saved successfully',
+//         campaign: updatedCampaign,
+//       });
+//   } catch (error) {
+//     console.error('Error saving campaign feedback:', error);
+//     res.status(500).json({ message: 'Internal server error' });
+//   }
+// };

--- a/API/src/modules/campaign/campaign.module.ts
+++ b/API/src/modules/campaign/campaign.module.ts
@@ -4,10 +4,11 @@ import { UserModule } from '../user/user.module';
 import { Campaign, CampaignSchema } from './schema/campaign.schema';
 import { MongooseModule } from '@nestjs/mongoose';
 import { ProjectModule } from '../project/project.module';
+import { CampaignController } from './campaign.controller';
 
 @Module({
   providers: [CampaignService],
-  controllers: [],
+  controllers: [CampaignController],
   exports: [CampaignService],
   imports: [
     UserModule,

--- a/API/src/modules/campaign/campaign.module.ts
+++ b/API/src/modules/campaign/campaign.module.ts
@@ -1,4 +1,20 @@
 import { Module } from '@nestjs/common';
+import { CampaignService } from './campaign.service';
+import { UserModule } from '../user/user.module';
+import { Campaign, CampaignSchema } from './schema/campaign.schema';
+import { MongooseModule } from '@nestjs/mongoose';
+import { ProjectModule } from '../project/project.module';
 
-@Module({})
+@Module({
+  providers: [CampaignService],
+  controllers: [],
+  exports: [CampaignService],
+  imports: [
+    UserModule,
+    ProjectModule,
+    MongooseModule.forFeature([
+      { name: Campaign.name, schema: CampaignSchema },
+    ]),
+  ],
+})
 export class CampaignModule {}

--- a/API/src/modules/campaign/campaign.service.ts
+++ b/API/src/modules/campaign/campaign.service.ts
@@ -1,0 +1,265 @@
+import { Injectable } from '@nestjs/common';
+import { UserService } from '../user/user.service';
+import { InjectModel } from '@nestjs/mongoose';
+import { Campaign } from './schema/campaign.schema';
+import { Model, Types } from 'mongoose';
+import { ProjectService } from '../project/project.service';
+import { Project } from '../project/schema/project.schema';
+import { Respondent } from './schema/subdocument/respondent.schema';
+
+interface ProjectWithTeam extends Project {
+  team?: Respondent[];
+}
+
+@Injectable()
+export class CampaignService {
+  constructor(
+    @InjectModel(Campaign.name) private campaignModel: Model<Campaign>,
+    private readonly userService: UserService,
+    private readonly projectService: ProjectService,
+  ) {}
+
+  async createCampaign(
+    title: string,
+    createdBy: string,
+    projects: ProjectWithTeam[],
+    description?: string,
+  ) {
+    if (!title || !createdBy || !projects) {
+      throw new Error('Title, createdBy, and projects are required');
+    }
+
+    const creatorId = await this.userService.findUserById(createdBy);
+    if (!creatorId) {
+      throw new Error("User's id provided not found in the database");
+    }
+
+    const projectsIds: Types.ObjectId[] =
+      await this.projectService.findOrCreateProjects(projects);
+
+    const campaignProjects = projectsIds.map((projectId, index) => {
+      const team = projects[index]?.team
+        ? projects[index].team.map((member: Respondent) => ({
+            fullName: member.fullName,
+            email: member.email,
+            role: member.role,
+            link: member.link,
+            responded: member.responded ?? false,
+          }))
+        : undefined;
+
+      return {
+        project: projectId,
+        team,
+      };
+    });
+
+    const newCampaign = {
+      title,
+      description,
+      createdBy: creatorId,
+      projects: campaignProjects,
+    };
+
+    return await this.campaignModel.create(newCampaign);
+  }
+
+  async getCampaignsByUser(userId: string) {
+    if (!userId) {
+      throw new Error('User ID is required');
+    }
+
+    return await this.campaignModel
+      .find({ createdBy: userId })
+      .populate('projects.project');
+  }
+  async getCampaignById(campaignId: string) {
+    if (!campaignId) {
+      throw new Error('Campaign ID is not set');
+    }
+    const campaign = await this.campaignModel
+      .findById(campaignId)
+      .populate('projects.project')
+      .populate('createdBy', 'email fullName');
+    if (!campaign) {
+      throw new Error('Campaign not found');
+    }
+    return campaign;
+  }
+  async getCampaignByLink(linkUuid: string) {
+    if (!linkUuid) {
+      throw new Error('Link is not set');
+    }
+    const campaign = await this.campaignModel
+      .findOne({ 'projects.team.link': { $regex: `${linkUuid}$` } })
+      .populate('projects.project')
+      .populate('createdBy', 'email firstName lastName');
+    if (!campaign) {
+      throw new Error('Campaign not found');
+    }
+
+    const projectEntry = campaign.projects.find((p) =>
+      p.team.some((member) => member.link.endsWith(linkUuid)),
+    );
+    if (!projectEntry) {
+      throw new Error('Project entry with the specified link not found');
+    }
+    const teamMember = projectEntry.team.find((member) =>
+      member.link.endsWith(linkUuid),
+    );
+    if (!teamMember) {
+      throw new Error('Team member with the specified link not found');
+    }
+    const campaignId = campaign._id.toString();
+    return {
+      campaignId: campaignId,
+      title: campaign.title,
+      requestor: {
+        fullName:
+          campaign.createdBy.firstName + ' ' + campaign.createdBy.lastName,
+        email: campaign.createdBy.email,
+      },
+      project: {
+        title: projectEntry.project.title,
+        projectStartDate: projectEntry.project.startDate,
+        projectEndDate: projectEntry.project.endDate,
+      },
+      teamMember: {
+        fullName: teamMember.fullName,
+        email: teamMember.email,
+        role: teamMember.role,
+        link: teamMember.link,
+      },
+    };
+  }
+}
+
+//       fullName: member.fullName,
+//       email: member.email,
+//       role: member.role,
+//       link: member.link,
+//       isResponded: member.isResponded ?? false,
+//       responseContents: member.responseContents ?? "",
+//     }));
+
+//     return {
+//       project: _id,
+//       team,
+//     };
+//   });
+
+//   const campaign = new Campaign({
+//     title,
+//     description,
+//     createdBy: creatorId,
+//     projects: campaignProjects,
+//   });
+
+//   await campaign.save();
+
+//   return campaign;
+// };
+
+// const getCampaignsByUser = async (userId) => {
+//   if (!userId) {
+//     throw new Error("User ID is required");
+//   }
+
+//   return Campaign.find({ createdBy: userId }).populate("projects.project");
+// };
+
+// const getCampaignByIdService = async (campaignId) => {
+//   if (!campaignId) {
+//     throw new Error("Campaign ID is not set");
+//   }
+//   const campaign = await Campaign.findById(campaignId).populate("projects.project").populate("createdBy", "email fullName");
+//   if (!campaign) {
+//     throw new Error("Campaign not found");
+//   }
+//   return campaign;
+// }
+
+// const getCampaignByLinkService = async (linkUuid) => {
+//   if (!linkUuid) {
+//     throw new Error("Link is not set");
+//   }
+//   const campaign = await Campaign.findOne({ "projects.team.link": { $regex: `${linkUuid}$` } })
+//     .populate("projects.project")
+//     .populate("createdBy", "email firstName lastName");
+//   if (!campaign) {
+//     throw new Error("Campaign not found");
+//   }
+
+//   const projectEntry = campaign.projects.find((p) => p.team.some((member) => member.link.endsWith(linkUuid)));
+//   if (!projectEntry) {
+//     throw new Error("Project entry with the specified link not found");
+//   }
+//   const teamMember = projectEntry.team.find((member) => member.link.endsWith(linkUuid));
+//   if (!teamMember) {
+//     throw new Error("Team member with the specified link not found");
+//   }
+//   const campaignId = campaign._id.toString();
+//   return {
+//     "campaignId": campaignId,
+//     "title": campaign.title,
+//     "requestor": {
+//       "fullName": campaign.createdBy.firstName + " " + campaign.createdBy.lastName,
+//       "email": campaign.createdBy.email,
+//     },
+//     "project": {
+//       "title": projectEntry.project.title,
+//       "projectStartDate": projectEntry.project.startDate,
+//       "projectEndDate": projectEntry.project.endDate,
+//     },
+//     "teamMember": {
+//       "fullName": teamMember.fullName,
+//       "email": teamMember.email,
+//       "role": teamMember.role,
+//       "link": teamMember.link,
+//       "isResponded": teamMember.responded,
+//       "responseContents": teamMember.responses || "",
+//     },
+//   }
+// };
+
+// const saveCampaignFeedbackService = async (campaignId, linkUuid, responseContents) => {
+//   if (!campaignId || !linkUuid || !responseContents) {
+//     throw new Error("Campaign ID, team member link, and response contents are required");
+//   }
+//   const campaign = await Campaign.findById(campaignId);
+//   if (!campaign) {
+//     throw new Error("Campaign not found");
+//   }
+//   const projectEntry = campaign.projects.find((p) => p.team.some((member) => member.link.endsWith(linkUuid)));
+//   if (!projectEntry) {
+//     throw new Error("Project entry with the specified link not found");
+//   }
+//   const savedFeedback = await Campaign.updateOne(
+//     { _id: campaignId, "projects.team.link": { $regex: `${linkUuid}$` } },
+//     {
+//       $set: { "projects.$[project].team.$[member].responded": true },
+//       $push: { "projects.$[project].team.$[member].responses": { content:responseContents} },
+//     },
+//     {
+//       arrayFilters: [
+//         { "project.project": projectEntry.project._id },
+//         { "member.link": { $regex: `${linkUuid}$` } }
+//       ]
+//     }
+//   );
+//   if (savedFeedback.modifiedCount === 0) {
+//     throw new Error("Failed to save feedback");
+//   }
+//   return {
+//     status: "success",
+//     message: "Feedback saved successfully",
+//   };
+// }
+
+// module.exports = {
+//   createCampaign,
+//   getCampaignsByUser,
+//   getCampaignByIdService,
+//   getCampaignByLinkService,
+//   saveCampaignFeedbackService,
+// };

--- a/API/src/modules/campaign/campaign.service.ts
+++ b/API/src/modules/campaign/campaign.service.ts
@@ -32,12 +32,7 @@ export class CampaignService {
     description?: string,
   ) {
     this.logger.debug(
-      `Creating campaign with parameters: ${JSON.stringify({
-        title,
-        createdBy,
-        projects,
-        description,
-      })}`,
+      `Creating campaign: title="${title}", createdBy=[REDACTED], projectsCount=${projects.length}, descriptionLength=${description ? description.length : 0}`
     );
 
     if (!title || !createdBy || !projects) {
@@ -82,7 +77,7 @@ export class CampaignService {
       projects: campaignProjects,
     };
 
-    this.logger.log('Creating new campaign:', newCampaign);
+    this.logger.log(`Creating new campaign: ${JSON.stringify(newCampaign)}`);
     return await this.campaignModel.create(newCampaign);
   }
 
@@ -294,7 +289,7 @@ export class CampaignService {
         role: teamMember.role,
         link: teamMember.link,
         isResponded: teamMember.isResponded,
-        responseContents: teamMember.responses || '',
+        responseContents: teamMember.responses || [],
       },
     };
   }

--- a/API/src/modules/campaign/campaign.service.ts
+++ b/API/src/modules/campaign/campaign.service.ts
@@ -11,6 +11,7 @@ import { Model, Types } from 'mongoose';
 import { ProjectService } from '../project/project.service';
 import { Project, ProjectDocument } from '../project/schema/project.schema';
 import { Respondent } from './schema/subdocument/respondent.schema';
+import { escapeRegex } from '@/common/helper/escape-regex.helper';
 
 interface ProjectWithTeam extends Project {
   team?: Respondent[];
@@ -32,7 +33,7 @@ export class CampaignService {
     description?: string,
   ) {
     this.logger.debug(
-      `Creating campaign: title="${title}", createdBy=[REDACTED], projectsCount=${projects.length}, descriptionLength=${description ? description.length : 0}`
+      `Creating campaign: title="${title}", createdBy=[REDACTED], projectsCount=${projects.length}, descriptionLength=${description ? description.length : 0}`,
     );
 
     if (!title || !createdBy || !projects) {
@@ -117,7 +118,9 @@ export class CampaignService {
     }
 
     const campaign = await this.campaignModel
-      .findOne({ 'projects.team.link': { $regex: `${linkUuid}$` } })
+      .findOne({
+        'projects.team.link': { $regex: `${escapeRegex(linkUuid)}$` },
+      })
       .populate('projects.project')
       .populate('createdBy', 'email firstName lastName');
     if (!campaign) {

--- a/API/src/modules/campaign/campaign.service.ts
+++ b/API/src/modules/campaign/campaign.service.ts
@@ -1,4 +1,9 @@
-import { Injectable, NotFoundException } from '@nestjs/common';
+import {
+  BadRequestException,
+  Injectable,
+  NotFoundException,
+  Logger,
+} from '@nestjs/common';
 import { UserService } from '../user/user.service';
 import { InjectModel } from '@nestjs/mongoose';
 import { Campaign, CampaignDocument } from './schema/campaign.schema';
@@ -13,6 +18,7 @@ interface ProjectWithTeam extends Project {
 
 @Injectable()
 export class CampaignService {
+  private readonly logger = new Logger(CampaignService.name);
   constructor(
     @InjectModel(Campaign.name) private campaignModel: Model<CampaignDocument>,
     private readonly userService: UserService,
@@ -25,13 +31,28 @@ export class CampaignService {
     projects: ProjectWithTeam[],
     description?: string,
   ) {
+    this.logger.debug(
+      `Creating campaign with parameters: ${JSON.stringify({
+        title,
+        createdBy,
+        projects,
+        description,
+      })}`,
+    );
+
     if (!title || !createdBy || !projects) {
-      throw new Error('Title, createdBy, and projects are required');
+      this.logger.warn('Missing required fields for creating campaign');
+      throw new BadRequestException(
+        'Title, createdBy, and projects are required',
+      );
     }
 
     const creatorId = await this.userService.findUserById(createdBy);
     if (!creatorId) {
-      throw new Error("User's id provided not found in the database");
+      this.logger.warn(`User not found: ${createdBy}`);
+      throw new NotFoundException(
+        "User's id provided not found in the database",
+      );
     }
 
     const projectsIds: Types.ObjectId[] =
@@ -61,14 +82,17 @@ export class CampaignService {
       projects: campaignProjects,
     };
 
+    this.logger.log('Creating new campaign:', newCampaign);
     return await this.campaignModel.create(newCampaign);
   }
 
   async getCampaignsByUser(userId: string) {
     if (!userId) {
-      throw new Error('User ID is required');
+      this.logger.warn('User ID is required');
+      throw new BadRequestException('User ID is required');
     }
 
+    this.logger.log(`Fetching campaigns for user ID: ${userId}`);
     return await this.campaignModel
       .find({ createdBy: new Types.ObjectId(userId) })
       .populate('projects.project');
@@ -76,30 +100,33 @@ export class CampaignService {
 
   async getCampaignById(campaignId: string) {
     if (!campaignId) {
-      throw new Error('Campaign ID is not set');
+      this.logger.warn('Campaign ID is not set');
+      throw new BadRequestException('Campaign ID is not set');
     }
     const campaign = await this.campaignModel
       .findById(campaignId)
       .populate('projects.project')
       .populate('createdBy', 'email fullName');
     if (!campaign) {
-      throw new Error('Campaign not found');
+      this.logger.warn(`Campaign not found: ${campaignId}`);
+      throw new NotFoundException('Campaign not found');
     }
+    this.logger.log(`Found campaign with ID: ${campaignId}`);
     return campaign;
   }
 
   async getCampaignByLink(linkUuid: string) {
     if (!linkUuid) {
-      throw new Error('Link is not set');
+      this.logger.warn('Link is not set');
+      throw new BadRequestException('Link is not set');
     }
 
-    console.log('Searching for campaign with link:', linkUuid);
-    
     const campaign = await this.campaignModel
       .findOne({ 'projects.team.link': { $regex: `${linkUuid}$` } })
       .populate('projects.project')
       .populate('createdBy', 'email firstName lastName');
     if (!campaign) {
+      this.logger.warn(`Campaign not found for link: ${linkUuid}`);
       throw new NotFoundException('Campaign not found');
     }
 
@@ -107,13 +134,19 @@ export class CampaignService {
       p.team.some((member) => member.link.endsWith(linkUuid)),
     );
     if (!projectEntry) {
-      throw new Error('Project entry with the specified link not found');
+      this.logger.warn(`Project entry not found for link: ${linkUuid}`);
+      throw new NotFoundException(
+        'Project entry with the specified link not found',
+      );
     }
     const teamMember = projectEntry.team.find((member) =>
       member.link.endsWith(linkUuid),
     );
     if (!teamMember) {
-      throw new Error('Team member with the specified link not found');
+      this.logger.warn(`Team member not found for link: ${linkUuid}`);
+      throw new NotFoundException(
+        'Team member with the specified link not found',
+      );
     }
 
     const projectDoc =
@@ -123,10 +156,12 @@ export class CampaignService {
         : null;
 
     if (!projectDoc) {
-      throw new Error('Project details not found');
+      this.logger.warn(`Project details not found for link: ${linkUuid}`);
+      throw new NotFoundException('Project details not found');
     }
 
     const campaignId = campaign._id.toString();
+    this.logger.log(`Found campaign details for link: ${linkUuid}`);
     return {
       campaignId: campaignId,
       title: campaign.title,
@@ -155,14 +190,16 @@ export class CampaignService {
     responseContents: string,
   ) {
     if (!campaignId || !linkUuid || !responseContents) {
-      throw new Error(
+      this.logger.warn('Missing required fields for saving feedback');
+      throw new BadRequestException(
         'Campaign ID, team member link, and response contents are required',
       );
     }
 
     const campaign = await this.campaignModel.findById(campaignId);
     if (!campaign) {
-      throw new Error('Campaign not found');
+      this.logger.warn(`Campaign not found: ${campaignId}`);
+      throw new NotFoundException('Campaign not found');
     }
 
     const projectEntry = campaign.projects.find((p) =>
@@ -170,46 +207,58 @@ export class CampaignService {
     );
 
     if (!projectEntry) {
-      throw new Error('Project entry with the specified link not found');
+      this.logger.warn(`Project entry not found for link: ${linkUuid}`);
+      throw new NotFoundException(
+        'Project entry with the specified link not found',
+      );
     }
 
-    const savedFeedback = await this.campaignModel.updateOne(
-      { _id: campaignId, 'projects.team.link': { $regex: `${linkUuid}$` } },
-      {
-        $set: { 'projects.$[project].team.$[member].responded': true },
-        $push: {
-          'projects.$[project].team.$[member].responses': {
-            content: responseContents,
+    try {
+      const savedFeedback = await this.campaignModel.updateOne(
+        { _id: campaignId, 'projects.team.link': { $regex: `${linkUuid}$` } },
+        {
+          $set: { 'projects.$[project].team.$[member].isResponded': true },
+          $push: {
+            'projects.$[project].team.$[member].responses': {
+              content: responseContents,
+            },
           },
         },
-      },
-      {
-        arrayFilters: [
-          // { 'project.project': projectEntry.project._id },
-          { 'project._id': projectEntry.project },
-          { 'member.link': { $regex: `${linkUuid}$` } },
-        ],
-      },
-    );
-
-    if (savedFeedback.modifiedCount === 0) {
+        {
+          arrayFilters: [
+            { 'project.project': projectEntry.project },
+            { 'member.link': { $regex: `${linkUuid}$` } },
+          ],
+        },
+      );
+      if (savedFeedback.modifiedCount === 0) {
+        throw new Error('Failed to save feedback');
+      }
+      this.logger.log(
+        `Feedback saved for campaignId: ${campaignId}, linkUuid: ${linkUuid}`,
+      );
+      return { status: 'success', message: 'Feedback saved successfully' };
+    } catch (error) {
+      this.logger.error(
+        `Error saving feedback for campaignId: ${campaignId}, linkUuid: ${linkUuid}`,
+        error,
+      );
       throw new Error('Failed to save feedback');
     }
-
-    return {
-      status: 'success',
-      message: 'Feedback saved successfully',
-    };
   }
 
   async getCampaignFeedback(campaignId: string, linkUuid: string) {
     if (!campaignId || !linkUuid) {
-      throw new Error('Campaign ID and team member link are required');
+      this.logger.warn('Campaign ID and team member link are required');
+      throw new BadRequestException(
+        'Campaign ID and team member link are required',
+      );
     }
 
     const campaign = await this.campaignModel.findById(campaignId);
     if (!campaign) {
-      throw new Error('Campaign not found');
+      this.logger.warn(`Campaign not found: ${campaignId}`);
+      throw new NotFoundException('Campaign not found');
     }
 
     const projectEntry = campaign.projects.find((p) =>
@@ -217,7 +266,10 @@ export class CampaignService {
     );
 
     if (!projectEntry) {
-      throw new Error('Project entry with the specified link not found');
+      this.logger.warn(`Project entry not found for link: ${linkUuid}`);
+      throw new NotFoundException(
+        'Project entry with the specified link not found',
+      );
     }
 
     const teamMember = projectEntry.team.find((member) =>
@@ -225,9 +277,15 @@ export class CampaignService {
     );
 
     if (!teamMember) {
-      throw new Error('Team member with the specified link not found');
+      this.logger.warn(`Team member not found for link: ${linkUuid}`);
+      throw new NotFoundException(
+        'Team member with the specified link not found',
+      );
     }
 
+    this.logger.log(
+      `Found feedback for campaignId: ${campaignId}, linkUuid: ${linkUuid}`,
+    );
     return {
       project: projectEntry.project,
       teamMember: {

--- a/API/src/modules/campaign/dto/campaign.dto.ts
+++ b/API/src/modules/campaign/dto/campaign.dto.ts
@@ -1,5 +1,13 @@
 import { ApiProperty } from '@nestjs/swagger';
-import { IsNotEmpty, IsOptional, IsString } from 'class-validator';
+import {
+  IsArray,
+  IsNotEmpty,
+  IsOptional,
+  IsString,
+  ValidateNested,
+} from 'class-validator';
+import { Type } from 'class-transformer';
+import { ProjectWithTeamDto } from './project-with-team.dto';
 
 export class CampaignDto {
   @ApiProperty({ description: 'The title of the campaign' })
@@ -12,4 +20,18 @@ export class CampaignDto {
   @IsOptional()
   description?: string;
 
+  @ApiProperty({ description: 'The ID of the user who created the campaign' })
+  @IsString()
+  @IsNotEmpty()
+  createdBy: string;
+
+  @ApiProperty({
+    description: 'The projects associated with the campaign',
+    type: [ProjectWithTeamDto],
+  })
+  @IsArray()
+  @ValidateNested({ each: true })
+  @Type(() => ProjectWithTeamDto)
+  @IsNotEmpty()
+  projects: ProjectWithTeamDto[];
 }

--- a/API/src/modules/campaign/dto/feedback.dto.ts
+++ b/API/src/modules/campaign/dto/feedback.dto.ts
@@ -1,0 +1,19 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { IsNotEmpty, IsString } from 'class-validator';
+
+export class FeedbackDto {
+  @ApiProperty({ description: 'The ID of the campaign' })
+  @IsString()
+  @IsNotEmpty()
+  campaignId: string;
+
+  @ApiProperty({ description: 'The unique link identifier' })
+  @IsString()
+  @IsNotEmpty()
+  linkUuid: string;
+
+  @ApiProperty({ description: 'The content of the feedback response' })
+  @IsString()
+  @IsNotEmpty()
+  responseContents: string;
+}

--- a/API/src/modules/campaign/dto/project-with-team.dto.ts
+++ b/API/src/modules/campaign/dto/project-with-team.dto.ts
@@ -1,0 +1,37 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { CreateProjectDto } from '../../project/dto/create-project.dto';
+import { RespondentDto } from './respondent.dto';
+import { Type } from 'class-transformer';
+import {
+  ArrayMinSize,
+  IsArray,
+  // IsNotEmpty,
+  // IsOptional,
+  ValidateNested,
+} from 'class-validator';
+
+export class ProjectWithTeamDto extends CreateProjectDto {
+  // @ApiProperty({
+  //   description: 'The start date of the project',
+  //   example: '2023-10-01T00:00:00Z',
+  // })
+  // @IsNotEmpty()
+  // startDate: Date;
+
+  // @ApiProperty({
+  //   description: 'The end date of the project',
+  //   example: '2023-12-31T00:00:00Z',
+  // })
+  // @IsOptional()
+  // endDate?: Date;
+
+  @ApiProperty({
+    description: 'The team members associated with the project',
+    type: [RespondentDto],
+  })
+  @IsArray()
+  @ArrayMinSize(1, { message: 'A project must have at least one team member.' })
+  @ValidateNested({ each: true })
+  @Type(() => RespondentDto)
+  team: RespondentDto[];
+}

--- a/API/src/modules/campaign/dto/project-with-team.dto.ts
+++ b/API/src/modules/campaign/dto/project-with-team.dto.ts
@@ -2,29 +2,9 @@ import { ApiProperty } from '@nestjs/swagger';
 import { CreateProjectDto } from '../../project/dto/create-project.dto';
 import { RespondentDto } from './respondent.dto';
 import { Type } from 'class-transformer';
-import {
-  ArrayMinSize,
-  IsArray,
-  // IsNotEmpty,
-  // IsOptional,
-  ValidateNested,
-} from 'class-validator';
+import { ArrayMinSize, IsArray, ValidateNested } from 'class-validator';
 
 export class ProjectWithTeamDto extends CreateProjectDto {
-  // @ApiProperty({
-  //   description: 'The start date of the project',
-  //   example: '2023-10-01T00:00:00Z',
-  // })
-  // @IsNotEmpty()
-  // startDate: Date;
-
-  // @ApiProperty({
-  //   description: 'The end date of the project',
-  //   example: '2023-12-31T00:00:00Z',
-  // })
-  // @IsOptional()
-  // endDate?: Date;
-
   @ApiProperty({
     description: 'The team members associated with the project',
     type: [RespondentDto],

--- a/API/src/modules/campaign/dto/respondent.dto.ts
+++ b/API/src/modules/campaign/dto/respondent.dto.ts
@@ -3,7 +3,6 @@ import {
   IsArray,
   IsEmail,
   IsNotEmpty,
-  IsOptional,
   IsString,
   ValidateNested,
 } from 'class-validator';
@@ -32,11 +31,26 @@ export class RespondentDto {
     example: 'Product Manager',
   })
   @IsString()
-  @IsOptional()
-  role?: string;
+  @IsNotEmpty()
+  role: string;
+
+  @ApiProperty({
+    description: 'Unique link for the respondent',
+    example:
+      'https://revyou-app.netlify.app/feedback/460945ee-b810-4051-9924-e4ec2fa75d32',
+  })
+  @IsString()
+  link: string;
+
+  @ApiProperty({
+    description: 'Whether the respondent has responded',
+    example: false,
+  })
+  @IsNotEmpty()
+  isResponded: boolean;
 
   @IsArray()
   @ValidateNested({ each: true })
   @Type(() => ResponseDto)
-  responses: ResponseDto[];
+  responses?: ResponseDto[] = [];
 }

--- a/API/src/modules/campaign/dto/response.dto.ts
+++ b/API/src/modules/campaign/dto/response.dto.ts
@@ -1,5 +1,11 @@
 import { ApiProperty } from '@nestjs/swagger';
-import { IsNotEmpty, IsString, MaxLength, MinLength } from 'class-validator';
+import {
+  IsNotEmpty,
+  IsString,
+  MaxLength,
+  MinLength,
+  IsDateString,
+} from 'class-validator';
 
 export class ResponseDto {
   // TODO: Consider varibale name alignment (responseContent vs content)
@@ -17,9 +23,6 @@ export class ResponseDto {
 
   @ApiProperty({ description: 'The date when the response was created' })
   @IsNotEmpty()
+  @IsDateString()
   createdAt: Date;
-
-  @ApiProperty({ description: 'The date when the response was last updated' })
-  @IsNotEmpty()
-  updatedAt: Date;
 }

--- a/API/src/modules/campaign/dto/response.dto.ts
+++ b/API/src/modules/campaign/dto/response.dto.ts
@@ -2,6 +2,8 @@ import { ApiProperty } from '@nestjs/swagger';
 import { IsNotEmpty, IsString, MaxLength, MinLength } from 'class-validator';
 
 export class ResponseDto {
+  // TODO: Consider varibale name alignment (responseContent vs content)
+
   @ApiProperty({ description: 'The content of the response' })
   @IsString()
   @MinLength(100, {

--- a/API/src/modules/campaign/dto/response.dto.ts
+++ b/API/src/modules/campaign/dto/response.dto.ts
@@ -12,4 +12,12 @@ export class ResponseDto {
   })
   @IsNotEmpty()
   content: string;
+
+  @ApiProperty({ description: 'The date when the response was created' })
+  @IsNotEmpty()
+  createdAt: Date;
+
+  @ApiProperty({ description: 'The date when the response was last updated' })
+  @IsNotEmpty()
+  updatedAt: Date;
 }

--- a/API/src/modules/campaign/schema/campaign.schema.ts
+++ b/API/src/modules/campaign/schema/campaign.schema.ts
@@ -21,7 +21,7 @@ export class Campaign {
     type: [
       {
         project: { type: Types.ObjectId, ref: Project.name },
-        team: [{ type: [RespondentSchema], default: [] }],
+        team: { type: [RespondentSchema], default: [] },
       },
     ],
   })

--- a/API/src/modules/campaign/schema/campaign.schema.ts
+++ b/API/src/modules/campaign/schema/campaign.schema.ts
@@ -1,8 +1,7 @@
 import { Prop, Schema, SchemaFactory } from '@nestjs/mongoose';
-import { HydratedDocument } from 'mongoose';
-import * as mongoose from 'mongoose';
+import { HydratedDocument, Types } from 'mongoose';
 import { User } from '@modules/user/schema/user.schema';
-import { Respondent } from './subdocument/respondent.schema';
+import { Respondent, RespondentSchema } from './subdocument/respondent.schema';
 import { Project } from '@modules/project/schema/project.schema';
 
 export type CampaignDocument = HydratedDocument<Campaign>;
@@ -15,19 +14,19 @@ export class Campaign {
   @Prop({ required: false })
   description: string;
 
-  @Prop({ type: mongoose.Schema.Types.ObjectId, ref: 'User' })
+  @Prop({ type: Types.ObjectId, ref: 'User' })
   createdBy: User;
 
   @Prop({
     type: [
       {
-        project: { type: mongoose.Schema.Types.ObjectId, ref: 'Project' },
-        team: [Respondent],
+        project: { type: Types.ObjectId, ref: Project.name },
+        team: [{ type: [RespondentSchema], default: [] }],
       },
     ],
   })
   projects: {
-    project: Project;
+    project: Types.ObjectId;
     team: Respondent[];
   }[];
 }

--- a/API/src/modules/campaign/schema/subdocument/respondent.schema.ts
+++ b/API/src/modules/campaign/schema/subdocument/respondent.schema.ts
@@ -16,10 +16,10 @@ export class Respondent {
   link: string;
 
   @Prop({ default: false })
-  responded: boolean;
+  isResponded: boolean;
 
   @Prop({ type: [Response], default: [] })
-  responses: Response[];
+  responses?: Response[];
 }
 
 export const RespondentSchema = SchemaFactory.createForClass(Respondent);

--- a/API/src/modules/example/example.controller.ts
+++ b/API/src/modules/example/example.controller.ts
@@ -6,7 +6,7 @@ import { Throttle, ThrottlerGuard } from '@nestjs/throttler';
 export class ExampleController {
   constructor(private readonly exampleService: ExampleService) {}
 
-  @Get()
+  @Get('/')
   printExample() {
     return {
       message: 'This is an example message from controller',

--- a/API/src/modules/example/example.module.ts
+++ b/API/src/modules/example/example.module.ts
@@ -4,6 +4,7 @@ import { ExampleController } from './example.controller';
 
 @Module({
   providers: [ExampleService],
-  controllers: [ExampleController]
+  controllers: [ExampleController],
+  exports: [ExampleService],
 })
 export class ExampleModule {}

--- a/API/src/modules/example/example.service.ts
+++ b/API/src/modules/example/example.service.ts
@@ -1,9 +1,13 @@
 import { Injectable } from '@nestjs/common';
+import { Logger } from '@nestjs/common';
 
 @Injectable()
 export class ExampleService {
+  private readonly logger = new Logger(ExampleService.name);
+
   // Example of a synchronous function
   printExample() {
+    this.logger.log('Printing example message');
     return 'This is an example message from controller';
   }
 }

--- a/API/src/modules/project/dto/create-project.dto.ts
+++ b/API/src/modules/project/dto/create-project.dto.ts
@@ -1,0 +1,28 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { IsNotEmpty, IsOptional, IsString } from 'class-validator';
+
+export class CreateProjectDto {
+  @ApiProperty({
+    description: 'The start date of the project',
+    example: '2023-10-01T00:00:00Z',
+  })
+  @IsNotEmpty()
+  startDate: Date;
+
+  @ApiProperty({
+    description: 'The end date of the project',
+    example: '2023-12-31T00:00:00Z',
+  })
+  @IsOptional()
+  endDate?: Date;
+
+  @ApiProperty({ description: 'The title of the project' })
+  @IsString()
+  @IsNotEmpty()
+  title: string;
+
+  @ApiProperty({ description: 'The description of the project' })
+  @IsString()
+  @IsOptional()
+  description?: string;
+}

--- a/API/src/modules/project/dto/project.dto.ts
+++ b/API/src/modules/project/dto/project.dto.ts
@@ -1,0 +1,20 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { IsNotEmpty, IsOptional, IsString, IsMongoId } from 'class-validator';
+import { Types } from 'mongoose';
+
+export class ProjectDto {
+  @ApiProperty({ description: 'The ID of the project' })
+  @IsMongoId()
+  @IsNotEmpty()
+  _id: Types.ObjectId;
+
+  @ApiProperty({ description: 'The title of the project' })
+  @IsString()
+  @IsNotEmpty()
+  title: string;
+
+  @ApiProperty({ description: 'The description of the project' })
+  @IsString()
+  @IsOptional()
+  description?: string;
+}

--- a/API/src/modules/project/project.module.ts
+++ b/API/src/modules/project/project.module.ts
@@ -1,4 +1,14 @@
 import { Module } from '@nestjs/common';
+import { ProjectService } from './project.service';
+import { MongooseModule } from '@nestjs/mongoose';
+import { Project, ProjectSchema } from './schema/project.schema';
 
-@Module({})
+@Module({
+  providers: [ProjectService],
+  controllers: [],
+  exports: [ProjectService],
+  imports: [
+    MongooseModule.forFeature([{ name: Project.name, schema: ProjectSchema }]),
+  ],
+})
 export class ProjectModule {}

--- a/API/src/modules/project/project.service.spec.ts
+++ b/API/src/modules/project/project.service.spec.ts
@@ -1,0 +1,18 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { ProjectService } from './project.service';
+
+describe('ProjectService', () => {
+  let service: ProjectService;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [ProjectService],
+    }).compile();
+
+    service = module.get<ProjectService>(ProjectService);
+  });
+
+  it('should be defined', () => {
+    expect(service).toBeDefined();
+  });
+});

--- a/API/src/modules/project/project.service.ts
+++ b/API/src/modules/project/project.service.ts
@@ -1,40 +1,28 @@
 import { Injectable } from '@nestjs/common';
 import { InjectModel } from '@nestjs/mongoose';
-import { Project } from './schema/project.schema';
+import { Project, ProjectDocument } from './schema/project.schema';
 import { Model, Types } from 'mongoose';
+import { CreateProjectDto } from './dto/create-project.dto';
 
 @Injectable()
 export class ProjectService {
   constructor(
-    @InjectModel(Project.name) private projectModel: Model<Project>,
+    @InjectModel(Project.name) private projectModel: Model<ProjectDocument>,
   ) {}
 
-  async findOrCreateProjects(projects: Project[]): Promise<Types.ObjectId[]> {
+  async findOrCreateProjects(projects: CreateProjectDto[]) {
     const projectIds: Types.ObjectId[] = [];
 
     for (const project of projects) {
-      let projectDoc: Partial<Project> | null;
-
-      if (project._id) {
-        projectDoc = await this.projectModel.findById(project._id);
-        if (!projectDoc?._id) {
-          throw new Error(
-            `Project with ID ${project._id.toString()} not found`,
-          );
-        }
-
-        projectIds.push(projectDoc._id);
-      } else {
-        projectDoc = {
-          title: project.title,
-          description: project.description || '',
-          startDate: project.startDate || new Date(),
-          endDate: project.endDate || null,
-        };
-
-        const newProject = await this.projectModel.create(projectDoc);
-        projectIds.push(newProject._id);
-      }
+      const projectDoc = await this.projectModel
+        .findOneAndUpdate(
+          { title: project.title },
+          { $setOnInsert: { ...project } },
+          { new: true, upsert: true },
+        )
+        .select('_id')
+        .exec();
+      projectIds.push(projectDoc._id);
     }
 
     return projectIds;

--- a/API/src/modules/project/project.service.ts
+++ b/API/src/modules/project/project.service.ts
@@ -1,0 +1,50 @@
+import { Injectable } from '@nestjs/common';
+import { InjectModel } from '@nestjs/mongoose';
+import { Project } from './schema/project.schema';
+import { Model, Types } from 'mongoose';
+
+@Injectable()
+export class ProjectService {
+  constructor(
+    @InjectModel(Project.name) private projectModel: Model<Project>,
+  ) {}
+
+  async findOrCreateProjects(projects: Project[]): Promise<Types.ObjectId[]> {
+    const projectIds: Types.ObjectId[] = [];
+
+    for (const project of projects) {
+      let projectDoc: Partial<Project> | null;
+
+      if (project._id) {
+        projectDoc = await this.projectModel.findById(project._id);
+        if (!projectDoc?._id) {
+          throw new Error(
+            `Project with ID ${project._id.toString()} not found`,
+          );
+        }
+
+        projectIds.push(projectDoc._id);
+      } else {
+        projectDoc = {
+          title: project.title,
+          description: project.description || '',
+          startDate: project.startDate || new Date(),
+          endDate: project.endDate || null,
+        };
+
+        const newProject = await this.projectModel.create(projectDoc);
+        projectIds.push(newProject._id);
+      }
+    }
+
+    return projectIds;
+  }
+
+  async searchProjectsByTitle(partialTitle: string): Promise<Project[]> {
+    return this.projectModel
+      .find({
+        title: { $regex: partialTitle, $options: 'i' },
+      })
+      .limit(10);
+  }
+}

--- a/API/src/modules/project/schema/project.schema.ts
+++ b/API/src/modules/project/schema/project.schema.ts
@@ -1,5 +1,5 @@
 import { Prop, Schema, SchemaFactory } from '@nestjs/mongoose';
-import { HydratedDocument } from 'mongoose';
+import { HydratedDocument, Types } from 'mongoose';
 
 export type ProjectDocument = HydratedDocument<Project>;
 
@@ -16,6 +16,8 @@ export class Project {
 
   @Prop({ required: false })
   endDate: Date;
+
+  _id: Types.ObjectId;
 }
 
 export const ProjectSchema = SchemaFactory.createForClass(Project);

--- a/API/src/modules/project/schema/project.schema.ts
+++ b/API/src/modules/project/schema/project.schema.ts
@@ -1,5 +1,5 @@
 import { Prop, Schema, SchemaFactory } from '@nestjs/mongoose';
-import { HydratedDocument, Types } from 'mongoose';
+import { HydratedDocument } from 'mongoose';
 
 export type ProjectDocument = HydratedDocument<Project>;
 
@@ -9,15 +9,13 @@ export class Project {
   title: string;
 
   @Prop({ required: false })
-  description: string;
+  description?: string;
 
   @Prop({ required: true })
   startDate: Date;
 
   @Prop({ required: false })
-  endDate: Date;
-
-  _id: Types.ObjectId;
+  endDate?: Date;
 }
 
 export const ProjectSchema = SchemaFactory.createForClass(Project);

--- a/API/src/modules/user/dto/user.dto.ts
+++ b/API/src/modules/user/dto/user.dto.ts
@@ -8,12 +8,15 @@ import {
 import { ApiProperty } from '@nestjs/swagger';
 
 export class UserDto {
-  @ApiProperty({ description: 'The Auth0 ID of the user' })
+  @ApiProperty({
+    description: 'The Auth0 ID of the user',
+    example: 'auth0|1234567890',
+  })
   @IsString()
   @IsNotEmpty()
   auth0Id: string;
 
-  @ApiProperty({ description: 'The username of the user' })
+  @ApiProperty({ description: 'The username of the user', example: 'john_doe' })
   @Matches('^[a-zA-Z0-9_.]+$', '', {
     message:
       'Username can only contain letters, numbers, underscores, or dots.',
@@ -21,21 +24,24 @@ export class UserDto {
   @IsNotEmpty()
   username: string;
 
-  @ApiProperty({ description: 'The first name of the user' })
+  @ApiProperty({ description: 'The first name of the user', example: 'John' })
   @Matches("^[a-zA-ZÀ-ÿ' -]+$", '', {
     message: 'First name contains invalid characters.',
   })
   @IsOptional()
   firstName?: string;
 
-  @ApiProperty({ description: 'The last name of the user' })
+  @ApiProperty({ description: 'The last name of the user', example: 'Doe' })
   @Matches("^[a-zA-ZÀ-ÿ' -]+$", '', {
     message: 'Last name contains invalid characters.',
   })
   @IsOptional()
   lastName?: string;
 
-  @ApiProperty({ description: 'The email of the user' })
+  @ApiProperty({
+    description: 'The email of the user',
+    example: 'john.doe@example.com',
+  })
   @IsEmail()
   @IsNotEmpty()
   email: string;

--- a/API/src/modules/user/user.controller.spec.ts
+++ b/API/src/modules/user/user.controller.spec.ts
@@ -1,0 +1,18 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { UserController } from './user.controller';
+
+describe('UserController', () => {
+  let controller: UserController;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [UserController],
+    }).compile();
+
+    controller = module.get<UserController>(UserController);
+  });
+
+  it('should be defined', () => {
+    expect(controller).toBeDefined();
+  });
+});

--- a/API/src/modules/user/user.controller.ts
+++ b/API/src/modules/user/user.controller.ts
@@ -1,0 +1,20 @@
+import { Body, Controller, Post } from '@nestjs/common';
+import { UserService } from './user.service';
+import { ApiOperation, ApiResponse, ApiTags } from '@nestjs/swagger';
+import { UserDto } from './dto/user.dto';
+
+@Controller('users')
+@ApiTags('Users')
+export class UserController {
+  constructor(private readonly userService: UserService) {}
+
+  // Temporary endpoint to create a user for testing purposes
+  @Post('/')
+  @ApiOperation({ summary: 'Create a new user (for testing purposes)' })
+  @ApiResponse({ status: 201, description: 'User created successfully.' })
+  @ApiResponse({ status: 400, description: 'Bad Request' })
+  @ApiResponse({ status: 500, description: 'Internal server error' })
+  async createUser(@Body() user: UserDto) {
+    return await this.userService.createUser(user);
+  }
+}

--- a/API/src/modules/user/user.module.ts
+++ b/API/src/modules/user/user.module.ts
@@ -1,4 +1,14 @@
 import { Module } from '@nestjs/common';
+import { UserSchema, User } from './schema/user.schema';
+import { MongooseModule } from '@nestjs/mongoose';
+import { UserService } from './user.service';
 
-@Module({})
+@Module({
+  imports: [
+    MongooseModule.forFeature([{ name: User.name, schema: UserSchema }]),
+  ],
+  providers: [UserService],
+  controllers: [],
+  exports: [UserService],
+})
 export class UserModule {}

--- a/API/src/modules/user/user.module.ts
+++ b/API/src/modules/user/user.module.ts
@@ -2,13 +2,14 @@ import { Module } from '@nestjs/common';
 import { UserSchema, User } from './schema/user.schema';
 import { MongooseModule } from '@nestjs/mongoose';
 import { UserService } from './user.service';
+import { UserController } from './user.controller';
 
 @Module({
   imports: [
     MongooseModule.forFeature([{ name: User.name, schema: UserSchema }]),
   ],
   providers: [UserService],
-  controllers: [],
+  controllers: [UserController],
   exports: [UserService],
 })
 export class UserModule {}

--- a/API/src/modules/user/user.service.spec.ts
+++ b/API/src/modules/user/user.service.spec.ts
@@ -1,0 +1,18 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { UserService } from './user.service';
+
+describe('UserService', () => {
+  let service: UserService;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [UserService],
+    }).compile();
+
+    service = module.get<UserService>(UserService);
+  });
+
+  it('should be defined', () => {
+    expect(service).toBeDefined();
+  });
+});

--- a/API/src/modules/user/user.service.ts
+++ b/API/src/modules/user/user.service.ts
@@ -1,0 +1,26 @@
+import { Injectable } from '@nestjs/common';
+import { InjectModel } from '@nestjs/mongoose';
+import { User } from './schema/user.schema';
+import { Model } from 'mongoose';
+
+@Injectable()
+export class UserService {
+  constructor(@InjectModel(User.name) private userModel: Model<User>) {}
+
+  async findUserById(id: string): Promise<User | null> {
+    return this.userModel.findById(id).exec();
+  }
+
+  async createUser(userData: Partial<User>): Promise<User> {
+    const newUser = new this.userModel(userData);
+    return newUser.save();
+  }
+
+  async updateUser(id: string, userData: Partial<User>): Promise<User | null> {
+    return this.userModel.findByIdAndUpdate(id, userData, { new: true }).exec();
+  }
+
+  async deleteUser(id: string): Promise<User | null> {
+    return this.userModel.findByIdAndDelete(id).exec();
+  }
+}


### PR DESCRIPTION
This commit adds functinality reletaed to campaigns keeping the same logic as per implementation in ExpressJS for the backward compatibility.

Added:
1. MongoDB schema entries
2. Input data validation with DTOs
3. Services implementation for Projects, Campaingns, and Users (for testing purposes)
4. Controllers implementation for Campaigns and Users (for testing purposes)