### PR TITLE
feat(cors): enables CORS protection

### DIFF
--- a/API/.env.example
+++ b/API/.env.example
@@ -4,6 +4,7 @@ NODE_ENV=production
 PORT=3000
 MONGO_URI=mongodb://localhost:27017 (Local development)
 MONGO_URI=mongodb+srv://user:password@atlas-cluster-name/?retryWrites=true&w=majority&appName=your-app-name (Atlas)
+CORS_ORIGINS=http://localhost:5173,http://your-production-domain.com
 
 # Throttling settings
 THROTTLE_TTL=60000

--- a/API/src/main.ts
+++ b/API/src/main.ts
@@ -15,6 +15,12 @@ async function bootstrap() {
     { bufferLogs: true },
   );
 
+  app.enableCors({
+    origin: process.env.CORS_ORIGINS?.split(',') || 'http://localhost:5173',
+    methods: 'GET,HEAD,PUT,PATCH,POST,DELETE,OPTIONS',
+    credentials: true,
+  });
+
   app.useGlobalPipes(new ValidationPipe({ whitelist: true, transform: true }));
 
   app.enableVersioning({


### PR DESCRIPTION
Enables CORS protection. 
The CORS_ORIGINS parameter has to be set with a white list of hosts. By default it's only http://localhost:5173 (Vite React APP)